### PR TITLE
typo correction

### DIFF
--- a/README.org
+++ b/README.org
@@ -72,7 +72,7 @@ Node.js v12 is needed for correct UDP/connect support.
 Run L7mp locally with a [[https://github.com/rg0now/l7mp/blob/master/config/l7mp-simple.yaml][sample]] static configuration.
 
 #+BEGIN_SRC sh
-node l7mp.js -c config/l7mp-simple.yaml -l warn
+node l7mp-proxy.js -c config/l7mp-simple.yaml -l warn
 #+END_SRC
 
 Configuration is accepted either in YAML format (if the extension is

--- a/l7mp.js
+++ b/l7mp.js
@@ -50,7 +50,7 @@ global.dump = function dump(o, depth=5){
     console.log(dumper(o, depth));
 }
 
-// validate object schamas beyond OpenAPI validation
+// validate object schemas beyond OpenAPI validation
 const validate = (object, schema) => {
     if(object === null || !object ||
        !(object instanceof Object &&


### PR DESCRIPTION
Fixed a typo and changed 
`node l7mp.js -c config/l7mp-simple.yaml -l warn`
to
`node l7mp-proxy.js -c config/l7mp-simple.yaml -l warn`
