### PR TITLE
Fix: API cluster test

### DIFF
--- a/test/20-api-cluster.test.js
+++ b/test/20-api-cluster.test.js
@@ -278,11 +278,8 @@ describe('Cluster-API', ()  => {
         });
 
         context('error',()=>{
- api-cluster-test
             it('add-existing-cluster', (done)=>{
 
-            it('add-existing-cluster', ()=>{
- master
                 const postData = JSON.stringify({
                     'cluster':{
                         name: 'L7mpControllerCluster',
@@ -303,12 +300,8 @@ describe('Cluster-API', ()  => {
                     });
                     response.on('end', () =>{
                         res = JSON.parse(str);
- api-cluster-test
-                        assert.include(res.status,400)
+                        assert.propertyVal(res, 'status', 400);
                         done();
-
-                        assert.include(res.content,'Cannot add')
- master
                     });
                 });
                 req.once('error', (e) =>{
@@ -317,11 +310,7 @@ describe('Cluster-API', ()  => {
                 req.write(postData);
                 req.end();
             });
- api-cluster-test
             it('delete-non-existing-cluster',(done)=>{
-
-            it('delete-non-existing-cluster',()=>{
- master
                 let options = {
                     host: 'localhost', port: 1234,
                     path: `/api/v1/clusters/non-existing-cluster`,
@@ -334,12 +323,9 @@ describe('Cluster-API', ()  => {
                     });
                     response.once('end', function () {
                         res = JSON.parse(str);
- api-cluster-test
-                        assert.include(res.status,400);
+                        assert.propertyVal(res, 'status', 400)
                         done();
 
-                        assert.include(res.content,'Cannot delete')
- master
                     });
 
                 }


### PR DESCRIPTION
In a previous version, error tests were compared by the response content instead of the response status code, now it is fixed.