### PR TITLE
Fix: API cluster test

### DIFF
--- a/test/20-api-cluster.test.js
+++ b/test/20-api-cluster.test.js
@@ -266,10 +266,10 @@ describe('Cluster-API', ()  => {
                     path: '/api/v1/clusters', method: 'POST'
                     , headers: {'Content-Type' : 'text/x-json', 'Content-length': postData.length}
                 }
-                return await httpRequest(options, postData)
+                return httpRequest(options, postData)
                     .then(
-                        () => Promise.reject(new Error('Expected method to reject.')),
-                        err => assert.instanceOf(err, Error)
+                        () =>{ return Promise.reject(new Error('Expected method to reject.'))},
+                        err => { assert.instanceOf(err, Error); return Promise.resolve()}
                     );
 
             });
@@ -279,10 +279,10 @@ describe('Cluster-API', ()  => {
                     path: `/api/v1/clusters/non-existing-cluster`,
                     method: 'DELETE'
                 };
-                return await httpRequest(options)
+                return httpRequest(options)
                     .then(
-                        () => Promise.reject(new Error('Expected method to reject.')),
-                        err => assert.instanceOf(err, Error)
+                        () =>{ return Promise.reject(new Error('Expected method to reject.'))},
+                        err => { assert.instanceOf(err, Error); return Promise.resolve(); }
                     );
             });
         });


### PR DESCRIPTION
Fixed asynchronous problems. Now requests wait for the previous request to be finished. So it won't try to get or delete a non existing cluster. 