### PR TITLE
Fix the VirtualService CRD

### DIFF
--- a/k8s-operator/crd.yml
+++ b/k8s-operator/crd.yml
@@ -17,12 +17,14 @@ spec:
       storage: true
       schema:
         openAPIV3Schema:
-          spec:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
+          type: object
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
       additionalPrinterColumns:
         - name: Selector
           type: string


### PR DESCRIPTION
For some reason the VirtualService CRD had a formatting issue that resulted in the following error:

`error: error validating "k8s-operator/crd.yml": error validating data: [ValidationError(CustomResourceDefinition.spec.versions[0].schema.openAPIV3Schema): unknown field "spec" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps, ValidationError(CustomResourceDefinition.spec.versions[0].schema.openAPIV3Schema): unknown field "status" in 
io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps]; if you choose to ignore these errors, turn validation off with --validate=false`

The pull request fixes this