### PR TITLE
Add Prometheus scraping pipeline to the static config if requested

### DIFF
--- a/helm-charts/l7mp-ingress/templates/configmap.yaml
+++ b/helm-charts/l7mp-ingress/templates/configmap.yaml
@@ -16,3 +16,18 @@ data:
               route:
                 destination:
                   spec: { protocol: L7mpController }
+{{- if eq .Values.l7mpProxy.prometheus "enable"}}
+      - name: prometheus_listener
+        spec: { protocol: HTTP, port: 8080 }
+        rules:
+          - match: {op: starts, path: '/HTTP/url/path', value: '/metrics'}
+            action:
+              route:
+                destination:
+                  spec: { protocol: Prometheus }
+    clusters:
+      - name: ingress-metric-counter
+        spec: { protocol: Metric }
+      - name: egress-metric-counter
+        spec: { protocol: Metric }
+{{- end }}

--- a/helm-charts/l7mp-ingress/templates/configmap.yaml
+++ b/helm-charts/l7mp-ingress/templates/configmap.yaml
@@ -25,9 +25,4 @@ data:
               route:
                 destination:
                   spec: { protocol: Prometheus }
-    clusters:
-      - name: ingress-metric-counter
-        spec: { protocol: Metric }
-      - name: egress-metric-counter
-        spec: { protocol: Metric }
 {{- end }}

--- a/helm-charts/l7mp-ingress/templates/daemonset.yaml
+++ b/helm-charts/l7mp-ingress/templates/daemonset.yaml
@@ -4,6 +4,9 @@ metadata:
   name: l7mp-ingress
   labels:
     apps: l7mp-ingress
+{{- if eq .Values.l7mpProxy.prometheus "enable"}}
+    prometheus: enable
+{{- end }}
 spec:
   selector:
     matchLabels:

--- a/helm-charts/l7mp-ingress/templates/service.yaml
+++ b/helm-charts/l7mp-ingress/templates/service.yaml
@@ -3,11 +3,21 @@ kind: Service
 metadata:
   labels:
     app: l7mp-ingress
+{{- if eq .Values.l7mpProxy.prometheus "enable"}}
+    prometheus: enable
+{{- end }}
   name: l7mp-ingress
 spec:
   ports:
-  - port: 1234
+  - name: controller-port
+    port: 1234
     protocol: TCP
     targetPort: 1234
+{{- if eq .Values.l7mpProxy.prometheus "enable"}}
+  - name: prometheus-port
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+{{- end }}
   selector:
     app: l7mp-ingress

--- a/helm-charts/l7mp-ingress/values.yaml
+++ b/helm-charts/l7mp-ingress/values.yaml
@@ -9,3 +9,4 @@ l7mpProxyImage:
 
 l7mpProxy:
   logLevel: info
+  prometheus: enable


### PR DESCRIPTION
Simply set l7mpProxy.prometheus=enable to add Prometheus config to the
l7mp ingress gateway.