### PR TITLE
Changed Grafana's data source's url 

### DIFF
--- a/helm-charts/l7mp-prometheus/templates/grafana.yaml
+++ b/helm-charts/l7mp-prometheus/templates/grafana.yaml
@@ -14,7 +14,7 @@ data:
                 "name": "prometheus",
                 "orgId": 1,
                 "type": "prometheus",
-                "url": "http://172.17.0.3:30900",
+                "url": " http://prometheus.monitoring.svc:9090",
                 "version": 1
             }
         ]


### PR DESCRIPTION
Changed Grafana's data source's URL to http://prometheus.monitoring.svc:9090. Now it should automatically find the correct data source. (In case of changing Prometheus svc's metadata.name, change the URL too)