### PR TITLE
Change selflink to a custom address #101

### DIFF
--- a/k8s-operator/l7mp.py
+++ b/k8s-operator/l7mp.py
@@ -38,7 +38,7 @@ from collections import defaultdict
 
 import kopf
 import l7mp_client
-from kopf.structs.diffs import diff
+from kopf._cogs.structs import bodies, dicts, diffs
 
 # State of the k8s cluster
 s = {

--- a/k8s-operator/l7mp.py
+++ b/k8s-operator/l7mp.py
@@ -52,7 +52,7 @@ s = {
 
 # https://stackoverflow.com/a/3233356
 def dict_update(d, u):
-    for k, v in u.items():
+    for k, v in u.items(): 
         if isinstance(v, collections.abc.Mapping):
             d[k] = dict_update(d.get(k, {}), v)
         else:
@@ -61,7 +61,11 @@ def dict_update(d, u):
 
 def get_fqn(obj):
     "Get a name unambiguously identifying the object OBJ."
-    return (obj['metadata']['selfLink'])
+    apiVersion = obj['apiVersion']
+    kind = obj['kind']
+    namespace = obj['metadata']['namespace']
+    name = obj['metadata']['name']
+    return (f'/{apiVersion}/{kind}/{namespace}/{name}')
 
 def get_l7mp_instance(pod):
     # cache the instance?

--- a/k8s-operator/l7mp.py
+++ b/k8s-operator/l7mp.py
@@ -52,7 +52,7 @@ s = {
 
 # https://stackoverflow.com/a/3233356
 def dict_update(d, u):
-    for k, v in u.items(): 
+    for k, v in u.items():
         if isinstance(v, collections.abc.Mapping):
             d[k] = dict_update(d.get(k, {}), v)
         else:

--- a/python-client/generate
+++ b/python-client/generate
@@ -8,7 +8,7 @@ def=l7mp-openapi.yaml
 cp ../openapi/$def .
 note="$(git describe --dirty --always --tags) ($(date -I))"
 
-docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli generate \
+docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli:v4.3.1 generate \
     -i /local/$def \
     -g python \
     -o /local/out \


### PR DESCRIPTION
With this update the l7mp-operator is compatible with k8s v1.20.2.
Changes: 
With selflink a destinationRef should look like this: `/apis/l7mp.io/v1/namespaces/default/targets/ingress-rtp-target`
Now: `/l7mp.io/v1/Target/default/ingress-rtp-target`