### PR TITLE
Use upstream node_bpf git for Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN cd /kernel-offload && make build
 
 # Prepare node_bpf npm package
 # get node_bpf source
-RUN git clone --depth 1 https://github.com/levaitamas/node_bpf.git -b musl
+RUN git clone --depth 1 https://github.com/mildsunrise/node_bpf.git
 
 # patch node-gyp config to link with installed libintl
 RUN  sed -i \


### PR DESCRIPTION
Had issues compiling [node_bpf](https://www.npmjs.com/package/bpf) with musl due to its archaic libelf version.
As a workaround, I forked node_bpf and we were pulling from my repo during Docker builds. 
The recent node_bpf release (v1.3.1) builds with musl and bumps deps (both libbpf and libelf) making this workaround obsolete.
